### PR TITLE
Adding automated React build checks

### DIFF
--- a/.github/workflows/react.js.yml
+++ b/.github/workflows/react.js.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: React Build
 
 on:
   push:
@@ -17,20 +17,23 @@ defaults:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build


### PR DESCRIPTION
Validates the ability to build the environment with the submitted changes on all branches for all actions. Having a failing build here means that this website will be impossible to build. If the build is successful, any deployment issue has already been isolated to the deployment environment.

Wallet dependencies may mean Node 16.6.0 is required. Without the proper version, the project cannot be built, and thus it is common practice just to remove those versions as this project is not backward-looking (okay for something that is not open source.)

That would be done on `[L25]` and just remove those versions from the array, leaving you with `[16.x]`